### PR TITLE
Centralize font-family selection

### DIFF
--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -15,8 +15,7 @@ import {
 import Svg, {Path} from 'react-native-svg';
 import {authHelpers} from '../lib/supabase';
 import {getErrorMessage} from '../utils/error';
-
-const baseFontFamily = Platform.OS === 'ios' ? 'System' : 'normal';
+import {baseFontFamily} from '../utils/platform';
 
 // Google Logo Icon
 const GoogleIcon: React.FC<{size?: number}> = ({size = 20}) => (

--- a/src/components/IdentityManager.tsx
+++ b/src/components/IdentityManager.tsx
@@ -12,6 +12,7 @@ import Svg, {Path} from 'react-native-svg';
 import {authHelpers} from '../lib/supabase';
 import {safeAwait} from '../utils/safeAwait';
 import {supabase} from '../lib/supabase';
+import {baseFontFamily} from '../utils/platform';
 
 // Use Supabase's UserIdentity type directly
 type UserIdentity = {
@@ -402,21 +403,21 @@ const styles = StyleSheet.create({
     marginLeft: 12,
     fontSize: 14,
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   title: {
     fontSize: 16,
     fontWeight: '600',
     color: '#000000',
     marginBottom: 4,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   subtitle: {
     fontSize: 14,
     color: '#666666',
     lineHeight: 20,
     marginBottom: 20,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   identitiesContainer: {
     marginBottom: 24,
@@ -451,12 +452,12 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     color: '#000000',
     marginBottom: 2,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   identityEmail: {
     fontSize: 14,
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   unlinkButton: {
     padding: 8,
@@ -473,7 +474,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#666666',
     marginBottom: 12,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   linkButton: {
     flexDirection: 'row',
@@ -502,7 +503,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '500',
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   linkButtonAction: {
     padding: 4,
@@ -512,7 +513,7 @@ const styles = StyleSheet.create({
     color: '#666666',
     lineHeight: 16,
     textAlign: 'center',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
 });
 

--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -20,6 +20,7 @@ import {safeAwait} from '../utils/safeAwait';
 import {journalEntriesService} from '../services/journalEntries';
 import {analyzeUserStreaks} from '../services/streakAnalytics';
 import IdentityManager from '../components/IdentityManager';
+import {baseFontFamily} from '../utils/platform';
 
 // Custom Icons
 const BackIcon: React.FC<{size?: number; color?: string}> = ({
@@ -579,7 +580,7 @@ const styles = StyleSheet.create({
     marginTop: 16,
     fontSize: 16,
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   header: {
     flexDirection: 'row',
@@ -597,13 +598,13 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: '600',
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   headerSubtitle: {
     fontSize: 14,
     color: '#666666',
     marginTop: 2,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   menuButton: {
     padding: 8,
@@ -635,7 +636,7 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: '600',
     color: '#FFFFFF',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   profileInfo: {
     flex: 1,
@@ -645,12 +646,12 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#000000',
     marginBottom: 4,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   profileEmail: {
     fontSize: 14,
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   statsSection: {
     flexDirection: 'row',
@@ -676,12 +677,12 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: '#000000',
     marginBottom: 4,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   statLabel: {
     fontSize: 12,
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   section: {
     backgroundColor: '#FFFFFF',
@@ -699,7 +700,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#666666',
     letterSpacing: 0.5,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   settingItem: {
     flexDirection: 'row',
@@ -728,12 +729,12 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     color: '#000000',
     marginBottom: 2,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   settingValue: {
     fontSize: 14,
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   editButton: {
     paddingHorizontal: 12,
@@ -747,7 +748,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#000000',
     fontWeight: '500',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   editContainer: {
     flexDirection: 'row',
@@ -765,7 +766,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#000000',
     backgroundColor: '#FFFFFF',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   saveButton: {
     backgroundColor: '#000000',
@@ -782,7 +783,7 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
     fontSize: 14,
     fontWeight: '500',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   chevron: {
     fontSize: 18,
@@ -812,7 +813,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '500',
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   dangerSectionTitle: {
     fontSize: 12,
@@ -820,12 +821,12 @@ const styles = StyleSheet.create({
     color: '#000000',
     letterSpacing: 0.5,
     marginBottom: 4,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   dangerSectionSubtitle: {
     fontSize: 12,
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   dangerActionButton: {
     flexDirection: 'row',
@@ -853,7 +854,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '500',
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   deleteSpinner: {
     marginLeft: 12,
@@ -867,12 +868,12 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#666666',
     marginBottom: 4,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   footerSubtext: {
     fontSize: 12,
     color: '#999999',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
 });
 

--- a/src/screens/AnalysisScreen.tsx
+++ b/src/screens/AnalysisScreen.tsx
@@ -20,6 +20,7 @@ import {
   type AnalysisData,
 } from '../services/ai';
 import {safeAwait} from '../utils/safeAwait';
+import {baseFontFamily} from '../utils/platform';
 import {getUserName} from '../services/onboarding';
 import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 import type {RootStackParamList} from '../navigation/AppNavigator';
@@ -802,13 +803,13 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: '600',
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   headerSubtitle: {
     fontSize: 14,
     color: '#666666',
     marginTop: 2,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   menuButton: {
     padding: 8,
@@ -835,13 +836,13 @@ const styles = StyleSheet.create({
     color: '#000000',
     marginTop: 16,
     marginBottom: 8,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   loadingSubtitle: {
     fontSize: 16,
     color: '#666666',
     marginBottom: 24,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   progressBarBackground: {
     width: 200,
@@ -871,12 +872,12 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#000000',
     marginBottom: 4,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   summary: {
     fontSize: 14,
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   section: {
     backgroundColor: '#FFFFFF',
@@ -897,7 +898,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#666666',
     letterSpacing: 0.5,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   categoryCount: {
     backgroundColor: '#E0E0E0',
@@ -909,7 +910,7 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: '600',
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   themesGrid: {
     gap: 12,
@@ -956,12 +957,12 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#000000',
     marginBottom: 2,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   themeDescription: {
     fontSize: 14,
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   themeAmount: {
     borderRadius: 8,
@@ -974,7 +975,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     color: '#FFFFFF',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   emotionsContainer: {
     gap: 16,
@@ -999,7 +1000,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '500',
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   emotionRight: {
     flexDirection: 'row',
@@ -1027,7 +1028,7 @@ const styles = StyleSheet.create({
     color: '#666666',
     minWidth: 40,
     textAlign: 'right',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   insightCard: {
     flexDirection: 'row',
@@ -1055,7 +1056,7 @@ const styles = StyleSheet.create({
     lineHeight: 22,
     color: '#000000',
     flex: 1,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   perspectiveCard: {
     flexDirection: 'row',
@@ -1083,7 +1084,7 @@ const styles = StyleSheet.create({
     lineHeight: 22,
     color: '#000000',
     flex: 1,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   loadingRow: {
     flexDirection: 'row',
@@ -1094,7 +1095,7 @@ const styles = StyleSheet.create({
     marginLeft: 12,
     fontSize: 15,
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   newEntryButton: {
     position: 'absolute',
@@ -1119,7 +1120,7 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
     fontSize: 24,
     fontWeight: '300',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   // Modal Styles
   modalContainer: {
@@ -1146,13 +1147,13 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: '600',
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   modalSubtitle: {
     fontSize: 14,
     color: '#666666',
     marginTop: 2,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   modalSpacer: {
     width: 40,
@@ -1188,12 +1189,12 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#000000',
     marginBottom: 4,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   modalThemeCount: {
     fontSize: 14,
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   modalSection: {
     backgroundColor: '#FFFFFF',
@@ -1206,13 +1207,13 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#000000',
     marginBottom: 12,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   modalBreakdown: {
     fontSize: 15,
     lineHeight: 22,
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   modalInsightItem: {
     flexDirection: 'row',
@@ -1232,7 +1233,7 @@ const styles = StyleSheet.create({
     lineHeight: 22,
     color: '#000000',
     flex: 1,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   reflectionCard: {
     backgroundColor: '#F8F8F8',
@@ -1245,7 +1246,7 @@ const styles = StyleSheet.create({
     lineHeight: 22,
     color: '#000000',
     fontStyle: 'italic',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   viewEntryButton: {
     position: 'absolute',
@@ -1270,7 +1271,7 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
     fontSize: 24,
     fontWeight: '300',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
 });
 

--- a/src/screens/EntryDetailScreen.tsx
+++ b/src/screens/EntryDetailScreen.tsx
@@ -17,6 +17,7 @@ import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 import type {RootStackParamList} from '../navigation/AppNavigator';
 import {journalEntriesService} from '../services/journalEntries';
 import {safeAwait} from '../utils/safeAwait';
+import {baseFontFamily} from '../utils/platform';
 import { Path, Circle, G } from 'react-native-svg';
 import Svg from 'react-native-svg';
 
@@ -185,7 +186,7 @@ const styles = StyleSheet.create({
     fontSize: 17,
     fontWeight: '600',
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   backButton: {
     paddingVertical: 4,
@@ -194,7 +195,7 @@ const styles = StyleSheet.create({
   backButtonText: {
     fontSize: 17,
     color: '#007AFF',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   placeholder: {
     width: 50,
@@ -212,7 +213,7 @@ const styles = StyleSheet.create({
   errorText: {
     fontSize: 17,
     color: '#888888',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   scrollView: {
     flex: 1,
@@ -224,14 +225,14 @@ const styles = StyleSheet.create({
     fontSize: 15,
     color: '#888888',
     marginBottom: 8,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   title: {
     fontSize: 22,
     fontWeight: 'bold',
     color: '#000000',
     marginBottom: 24,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   entryContainer: {
     marginBottom: 24,
@@ -240,7 +241,7 @@ const styles = StyleSheet.create({
     fontSize: 17,
     lineHeight: 26,
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   aiContainer: {
     flexDirection: 'row',
@@ -257,7 +258,7 @@ const styles = StyleSheet.create({
     fontSize: 17,
     lineHeight: 26,
     color: '#007AFF',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
     flex: 1,
   },
   footer: {

--- a/src/screens/EntryScreen.tsx
+++ b/src/screens/EntryScreen.tsx
@@ -18,6 +18,7 @@ import {analyseJournalEntry, generateTitleFromEntry} from '../services/ai';
 import {safeAwait} from '../utils/safeAwait';
 import {useNavigation} from '@react-navigation/native';
 import type {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {baseFontFamily} from '../utils/platform';
 import type {RootStackParamList} from '../navigation/AppNavigator';
 import {
   journalEntriesService,
@@ -331,7 +332,7 @@ const styles = StyleSheet.create({
     fontSize: 17,
     lineHeight: 26,
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   aiContainer: {
     flexDirection: 'row',
@@ -348,7 +349,7 @@ const styles = StyleSheet.create({
     fontSize: 17,
     lineHeight: 26,
     color: '#007AFF',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
     flex: 1,
   },
   loadingContainer: {
@@ -365,7 +366,7 @@ const styles = StyleSheet.create({
     color: '#000000',
     padding: 0,
     textAlignVertical: 'top',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
     minHeight: 100,
   },
   spacer: {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -18,6 +18,7 @@ import {journalEntriesService, JournalEntry} from '../services/journalEntries';
 import {safeAwait} from '../utils/safeAwait';
 import {getUserName} from '../services/onboarding';
 import {getMostCommonEmotion, getEmotionEmoji, type EmotionSummary} from '../services/emotionAnalytics';
+import {baseFontFamily} from '../utils/platform';
 import {getMostCommonTheme, getThemeEmoji, type ThemeSummary} from '../services/themeAnalytics';
 import {getStreakEmoji, getStreakMessage, type StreakSummary, analyzeUserStreaks} from '../services/streakAnalytics';
 import { Path } from 'react-native-svg';
@@ -376,7 +377,7 @@ const styles = StyleSheet.create({
   loadingText: {
     fontSize: 16,
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   listContent: {
     paddingBottom: 100,
@@ -399,13 +400,13 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: '600',
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   headerSubtitle: {
     fontSize: 14,
     color: '#666666',
     marginTop: 2,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   menuButton: {
     position: 'absolute',
@@ -430,12 +431,12 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#000000',
     marginBottom: 4,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   comparison: {
     fontSize: 14,
     color: '#666666',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   analyticsSection: {
     backgroundColor: '#FFFFFF',
@@ -466,7 +467,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#666666',
     letterSpacing: 0.5,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   categoryCount: {
     backgroundColor: '#E0E0E0',
@@ -478,7 +479,7 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: '600',
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   categoriesGrid: {
     gap: 12,
@@ -509,13 +510,13 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '500',
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   categoryValue: {
     fontSize: 12,
     color: '#666666',
     marginTop: 2,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   streakMessage: {
     alignSelf: 'center',
@@ -530,7 +531,7 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     color: '#000000',
     textAlign: 'center',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   entriesSection: {
 
@@ -578,14 +579,14 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#000000',
     marginBottom: 4,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   entryDescription: {
     fontSize: 14,
     color: '#666666',
     lineHeight: 20,
     marginBottom: 8,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   entryMeta: {
     marginBottom: 12,
@@ -593,13 +594,13 @@ const styles = StyleSheet.create({
   entryLocation: {
     fontSize: 12,
     color: '#999999',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   entryDate: {
     fontSize: 12,
     fontWeight: '600',
     color: '#999999',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   entryActions: {
     flexDirection: 'row',
@@ -630,14 +631,14 @@ const styles = StyleSheet.create({
     color: '#000000',
     textAlign: 'center',
     marginBottom: 8,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   emptyText: {
     fontSize: 14,
     color: '#666666',
     textAlign: 'center',
     lineHeight: 20,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   newEntryButton: {
     position: 'absolute',
@@ -662,7 +663,7 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
     fontSize: 24,
     fontWeight: '300',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
 });
 

--- a/src/screens/ResultsScreen.tsx
+++ b/src/screens/ResultsScreen.tsx
@@ -8,6 +8,7 @@ import {
   TouchableOpacity,
   Platform,
 } from 'react-native';
+import {baseFontFamily} from '../utils/platform';
 
 const mockResults = {
   tasks: [
@@ -73,7 +74,7 @@ const styles = StyleSheet.create({
     fontSize: 17,
     fontWeight: '600',
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   content: {
     padding: 20,
@@ -86,7 +87,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#000000',
     marginBottom: 16,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   taskItem: {
     flexDirection: 'row',
@@ -120,13 +121,13 @@ const styles = StyleSheet.create({
   taskText: {
     fontSize: 17,
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   taskTextDone: {
     fontSize: 17,
     color: '#888888',
     textDecorationLine: 'line-through',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
 });
 

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -7,6 +7,7 @@ import {
   ScrollView,
   Platform,
 } from 'react-native';
+import {baseFontFamily} from '../utils/platform';
 
 const mockStats = {
   totalTime: '2h 30m',
@@ -84,7 +85,7 @@ const styles = StyleSheet.create({
     fontSize: 17,
     fontWeight: '600',
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   scrollView: {
     flex: 1,
@@ -110,12 +111,12 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#000000',
     marginBottom: 6,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   statLabel: {
     fontSize: 13,
     color: '#888888',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   sectionContainer: {
     marginBottom: 24,
@@ -125,7 +126,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#000000',
     marginBottom: 12,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   activityCard: {
     backgroundColor: '#F5F5F7',
@@ -137,12 +138,12 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     color: '#000000',
     marginBottom: 4,
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   activitySubtext: {
     fontSize: 13,
     color: '#888888',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   insightCard: {
     backgroundColor: '#F5F5F7',
@@ -156,13 +157,13 @@ const styles = StyleSheet.create({
   insightTitle: {
     fontSize: 15,
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
   insightValue: {
     fontSize: 15,
     fontWeight: '500',
     color: '#000000',
-    fontFamily: Platform.OS === 'ios' ? 'System' : 'normal',
+    fontFamily: baseFontFamily,
   },
 });
 

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,3 @@
+import {Platform} from 'react-native';
+
+export const baseFontFamily = Platform.OS === 'ios' ? 'System' : 'normal';


### PR DESCRIPTION
## Summary
- add `src/utils/platform.ts` with `baseFontFamily`
- import and use `baseFontFamily` across components and screens

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9fdcfa248329ac4e9052f3274e11